### PR TITLE
Use stock trioBlack app icon instead of the Elmo icon

### DIFF
--- a/Config.xcconfig
+++ b/Config.xcconfig
@@ -1,6 +1,6 @@
 // Some of the items can be modified to match the user's preference
 APP_DISPLAY_NAME = Trio
-APP_ICON = Elmo
+APP_ICON = trioBlack
 APP_URL_SCHEME = Trio
 
 // DEVELOPER_TEAM will be set to your Apple Developer ID - typically using ConfigOverride.xcconfig


### PR DESCRIPTION
This branch is otherwise an exact copy of dev (all merged features intact) -- just swaps APP_ICON back from the personal Elmo icon to trioBlack, the same default nightscout/trio ships with. Config-only change, no dosing/pump/sensor code touched.